### PR TITLE
refactor: use React context for app config

### DIFF
--- a/propertiesmanager-ui/src/Components/App.js
+++ b/propertiesmanager-ui/src/Components/App.js
@@ -13,29 +13,35 @@ import { Rings } from 'react-loader-spinner';
 
 export default function App() {
 
-  	const [loading, setLoading] = useState(1);
+        const [loading, setLoading] = useState(1);
+        const [app, setApp] = useState();
   	
   	const navigate = useNavigate();
 
-	useEffect(() => {
-		console.log("Init events");
-		
-		// eslint-disable-next-line no-unused-expressions
-		AppContext.app===undefined?initConfig():null;
-		
-		if (document.readyState === "complete") {
-			subscribe("startLoadingEvent", () => {
-				console.log("startLoadingEvent");
-				setLoading(loading+1);
-			});
-			subscribe("endLoadingEvent", () => {
-				console.log("endLoadingEvent");
-				setLoading(loading>0?loading-1:0);
-			});
-			
-		}
-		
-	}, [loading]);
+        useEffect(() => {
+                console.log("Init events");
+
+                if (app === undefined) {
+                        initConfig();
+                }
+
+                if (document.readyState === "complete") {
+                        subscribe("startLoadingEvent", () => {
+                                console.log("startLoadingEvent");
+                                setLoading(loading + 1);
+                        });
+                        subscribe("endLoadingEvent", () => {
+                                console.log("endLoadingEvent");
+                                setLoading(loading > 0 ? loading - 1 : 0);
+                        });
+
+                }
+
+        }, [loading, app]);
+
+        useEffect(() => {
+                AppContext.app = app;
+        }, [app]);
 	
 	function initConfig() {
 		console.log("Init config...");
@@ -49,8 +55,8 @@ export default function App() {
 		.then(res => res.json())
 		.then((data) => {
 			console.log("Response config success : ", data);
-			AppContext.app = data;
-			setLoading(loading>0?loading-1:0);
+                        setApp(data);
+                        setLoading(loading>0?loading-1:0);
 		})
 		.catch((e) => {
 			console.error("Response config error : ", e);
@@ -59,23 +65,25 @@ export default function App() {
 		});
 	}
 
-	return (
-		<React.Fragment>
-			<Rings visible={loading > 0}
-				color="red"
-				radius={300}
-				width={300}
-				height={300}
-				wrapperClass="loading-overlay" />
-			<div className="main-header">
-				<Header />
-			</div>
-			<div className="main-body">
-				<AppRouter  />
-			</div>
-			<div className="main-footer">
-				<Footer />
-			</div>
-		</React.Fragment>
-	);
+        return (
+                <AppContext.Provider value={{ app, setApp }}>
+                        <React.Fragment>
+                                <Rings visible={loading > 0}
+                                        color="red"
+                                        radius={300}
+                                        width={300}
+                                        height={300}
+                                        wrapperClass="loading-overlay" />
+                                <div className="main-header">
+                                        <Header />
+                                </div>
+                                <div className="main-body">
+                                        <AppRouter />
+                                </div>
+                                <div className="main-footer">
+                                        <Footer />
+                                </div>
+                        </React.Fragment>
+                </AppContext.Provider>
+        );
 }

--- a/propertiesmanager-ui/src/Components/AppContext.js
+++ b/propertiesmanager-ui/src/Components/AppContext.js
@@ -1,26 +1,12 @@
-export default {
-	app: undefined,
-	lastErrorMessage: ''
-}
+import React from 'react';
 
-/*
+const AppContext = React.createContext({
+        app: undefined,
+        setApp: () => {}
+});
 
-	app content exemple (location : config/config.json) :
+// Legacy fields to maintain compatibility
+AppContext.app = undefined;
+AppContext.lastErrorMessage = '';
 
-	{
-		"API_ROOT_URL": "http://localhost:10000/pm-api",
-		"lang": "fr-FR",
-		"env": [
-				"dev",
-				"tst",
-				"rec",
-				"prepro",
-				"pro"
-			],
-		"keycloak_init_options" : {
-			"onLoad": "check-sso",
-			"silentCheckSsoRedirectUri": "/silent-check-sso.html",
-			"checkLoginIframe": false
-		}
-	}
-*/
+export default AppContext;

--- a/propertiesmanager-ui/src/Components/kustom/AppRouter.js
+++ b/propertiesmanager-ui/src/Components/kustom/AppRouter.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 
 import { useKeycloak } from '@react-keycloak/web';
@@ -15,7 +15,8 @@ import AppContext from "../AppContext";
 
 export default function AppRouter() {
 
-	const { keycloak, } = useKeycloak();
+        const { keycloak, } = useKeycloak();
+        const { app } = useContext(AppContext);
 
 	return (
 			<Routes>
@@ -36,7 +37,7 @@ export default function AppRouter() {
 	);
 	
 	function globalCondition(action) {
-		return AppContext.app!==undefined?action:<Error errNum="500" />;
+                return app!==undefined?action:<Error errNum="500" />;
 	}
 	
 	function security(action) {

--- a/propertiesmanager-ui/src/Components/kustom/pages/appdetails/AppDetails.js
+++ b/propertiesmanager-ui/src/Components/kustom/pages/appdetails/AppDetails.js
@@ -1,6 +1,6 @@
 import './AppDetails.css';
 
-import React, { useReducer, useState, useEffect } from 'react';
+import React, { useReducer, useState, useEffect, useContext } from 'react';
 import { useNavigate, useParams } from "react-router-dom";
 
 import Keycloak from '../../../Keycloak';
@@ -19,7 +19,8 @@ export default function AppDetails() {
 	
   	const { t } = useTranslation();
 
-	const { keycloak, } = useKeycloak();
+        const { keycloak, } = useKeycloak();
+        const { app } = useContext(AppContext);
 	
 	/* INIT */
 
@@ -58,11 +59,11 @@ export default function AppDetails() {
 
 	/* HOOKS */
 	
-	useEffect(() => {
-		AppContext.app!=undefined?
-			setEnvList(AppContext.app.env)
-			:null;
-	}, [AppContext.app]);
+        useEffect(() => {
+                app!=undefined?
+                        setEnvList(app.env)
+                        :null;
+        }, [app]);
 	
 	useEffect(() => {
 			console.log("keycloak and/or envList change", keycloak, envList);

--- a/propertiesmanager-ui/src/Components/kustom/pages/applist/AppList.js
+++ b/propertiesmanager-ui/src/Components/kustom/pages/applist/AppList.js
@@ -1,6 +1,6 @@
 import './AppList.css';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { Link } from "react-router-dom";
 
 import AppContext from "../../../AppContext";
@@ -14,7 +14,8 @@ export default function AppList() {
 	
   	const { t } = useTranslation();
 
-	const { keycloak, } = useKeycloak();
+        const { keycloak, } = useKeycloak();
+        const { app } = useContext(AppContext);
 	
 	/* INIT */
 
@@ -42,11 +43,11 @@ export default function AppList() {
 
 	/* HOOKS */
 	
-	useEffect(() => {
-		AppContext.app!=undefined?
-			setEnvList(AppContext.app.env)
-			:null;
-	}, [AppContext.app]);
+        useEffect(() => {
+                app!=undefined?
+                        setEnvList(app.env)
+                        :null;
+        }, [app]);
 	
 	useEffect(() => {
 		if (keycloak.authenticated && envList !== undefined) {

--- a/propertiesmanager-ui/src/Components/kustom/pages/confighelper/ConfigHelper.js
+++ b/propertiesmanager-ui/src/Components/kustom/pages/confighelper/ConfigHelper.js
@@ -1,6 +1,6 @@
 import './ConfigHelper.css';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 
 import { useKeycloak } from '@react-keycloak/web';
 
@@ -14,7 +14,8 @@ export default function ConfigHelper() {
 	
   	const { t } = useTranslation();
 
-	const { keycloak, } = useKeycloak();
+        const { keycloak, } = useKeycloak();
+        const { app } = useContext(AppContext);
 
 	const [envList, setEnvList] = useState();
 	
@@ -42,11 +43,11 @@ export default function ConfigHelper() {
 
 	/* HOOKS */
 	
-	useEffect(() => {
-		AppContext.app!=undefined?
-			setEnvList(AppContext.app.env)
-			:null;
-	}, [AppContext.app]);
+        useEffect(() => {
+                app!=undefined?
+                        setEnvList(app.env)
+                        :null;
+        }, [app]);
 	
 	useEffect(() => {
 		if (keycloak.authenticated && envList != undefined) {

--- a/propertiesmanager-ui/src/Components/kustom/pages/globalvariables/GlobalVariables.js
+++ b/propertiesmanager-ui/src/Components/kustom/pages/globalvariables/GlobalVariables.js
@@ -1,6 +1,6 @@
 import './GlobalVariables.css';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 
 import { useKeycloak } from '@react-keycloak/web';
 
@@ -14,7 +14,8 @@ import { t } from 'i18next';
 
 export default function GlobalVariables() {
 
-	const { keycloak, } = useKeycloak();
+        const { keycloak, } = useKeycloak();
+        const { app } = useContext(AppContext);
 
 	const [envList, setEnvList] = useState();
 
@@ -31,11 +32,11 @@ export default function GlobalVariables() {
 
 	/* HOOKS */
 	
-	useEffect(() => {
-		AppContext.app!=undefined?
-			setEnvList(AppContext.app.env)
-			:null;
-	}, [AppContext.app]);
+        useEffect(() => {
+                app!=undefined?
+                        setEnvList(app.env)
+                        :null;
+        }, [app]);
 	
 	useEffect(() => {
 		if (keycloak.authenticated && envList != undefined) {

--- a/propertiesmanager-ui/src/Components/kustom/pages/user/Profile.js
+++ b/propertiesmanager-ui/src/Components/kustom/pages/user/Profile.js
@@ -1,6 +1,6 @@
 import './Profile.css';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 
 import { useKeycloak } from '@react-keycloak/web';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -14,7 +14,8 @@ import { useTranslation } from 'react-i18next';
 
 export default function Profile() {
 
-	const { keycloak, } = useKeycloak();
+        const { keycloak, } = useKeycloak();
+        const { app } = useContext(AppContext);
 
 	const [envList, setEnvList] = useState();
 
@@ -40,11 +41,11 @@ export default function Profile() {
 
 	/* HOOKS */
 	
-	useEffect(() => {
-		AppContext.app!=undefined?
-			setEnvList(AppContext.app.env)
-			:null;
-	}, [AppContext.app]);
+        useEffect(() => {
+                app!=undefined?
+                        setEnvList(app.env)
+                        :null;
+        }, [app]);
 	
 	useEffect(() => {
 		if (keycloak.authenticated) {

--- a/propertiesmanager-ui/src/index.js
+++ b/propertiesmanager-ui/src/index.js
@@ -9,7 +9,6 @@ import Keycloak from './Components/Keycloak';
 
 import './index.css';
 import App from './Components/App';
-import AppContext from './Components/AppContext';
 
 import './Components/kustom/i18n';
 import { BrowserRouter } from 'react-router-dom';
@@ -27,7 +26,6 @@ function Root() {
                 })
                 .then(res => res.json())
                 .then(data => {
-                        AppContext.app = data;
                         setConfig(data);
                 })
                 .catch(e => {


### PR DESCRIPTION
## Summary
- replace static app context object with React.createContext
- wrap application in AppContext.Provider and manage app via useState
- update pages like AppList and routing to consume app via useContext

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aad9fc62e0832cb05509a3610668f6