### PR TITLE
Redirect unauthenticated users to Keycloak login

### DIFF
--- a/propertiesmanager-ui/src/Components/kustom/AppRouter.js
+++ b/propertiesmanager-ui/src/Components/kustom/AppRouter.js
@@ -3,7 +3,7 @@ import { Routes, Route, Navigate } from "react-router-dom";
 
 import { useKeycloakInstance } from '../Keycloak';
 
-import Error, { ForbiddenError, NotFoundError } from "../kernel/error/Error";
+import Error, { NotFoundError } from "../kernel/error/Error";
 import Copyright from "../kernel/copyright/Copyright";
 
 import AppList from './pages/applist/AppList';
@@ -38,7 +38,11 @@ export default function AppRouter() {
                 return app!==undefined?action:<Error errNum="500" />;
 	}
 	
-	function security(action) {
-		return keycloak.authenticated?action:<ForbiddenError errNum="403" />;
-	}
+        function security(action) {
+                if (!keycloak.authenticated) {
+                        keycloak.login();
+                        return null;
+                }
+                return action;
+        }
 }


### PR DESCRIPTION
## Summary
- Redirect users who aren't authenticated to Keycloak's login screen

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68ab0b2ee30c832cb505080686ea6aca