### PR TITLE
fix: guard against missing keycloak login

### DIFF
--- a/propertiesmanager-ui/src/Components/kustom/AppRouter.js
+++ b/propertiesmanager-ui/src/Components/kustom/AppRouter.js
@@ -43,8 +43,10 @@ export default function AppRouter() {
                         return null;
                 }
 
-                if (!keycloak?.authenticated) {
-                        keycloak?.login();
+                if (!keycloak.authenticated) {
+                        if (typeof keycloak.login === 'function') {
+                                keycloak.login();
+                        }
                         return null;
                 }
 

--- a/propertiesmanager-ui/src/Components/kustom/AppRouter.js
+++ b/propertiesmanager-ui/src/Components/kustom/AppRouter.js
@@ -43,8 +43,8 @@ export default function AppRouter() {
                         return null;
                 }
 
-                if (!keycloak.authenticated) {
-                        keycloak.login();
+                if (!keycloak?.authenticated) {
+                        keycloak?.login();
                         return null;
                 }
 


### PR DESCRIPTION
## Summary
- prevent crash when Keycloak instance is undefined by checking for login method with optional chaining

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ab2ace41a0832c86a8861f4a9c3799