### PR TITLE
Enable env-aware build and package distribution

### DIFF
--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -16,9 +16,9 @@ jobs:
         working-directory: propertiesmanager-ui
         run: |
           npm install
-          npm run build
+          npm run build:dev
       - name: Build backend
-        run: ./build-all.sh
+        run: ./build-all.sh dev
       - name: Deploy site
         run: |
           rm -rf /opt/props/props-ui-dev

--- a/.github/workflows/build_pro.yml
+++ b/.github/workflows/build_pro.yml
@@ -16,9 +16,9 @@ jobs:
       working-directory: propertiesmanager-ui
       run: |
         npm install
-        npm run build
+        npm run build:pro
     - name: Build backend
-      run: ./build-all.sh
+      run: ./build-all.sh pro
     - name: Deploy site
       run: |
         rm -rf /opt/props/props-ui-pro

--- a/.github/workflows/build_rec.yml
+++ b/.github/workflows/build_rec.yml
@@ -14,9 +14,9 @@ jobs:
       working-directory: propertiesmanager-ui
       run: |
         npm install
-        npm run build
+        npm run build:rec
     - name: Build backend
-      run: ./build-all.sh
+      run: ./build-all.sh rec
     - name: Deploy site
       run: |
         rm -rf /opt/props/props-ui-rec

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ local.properties
 /node_modules/
 /build/
 /package-lock.json
+/dist/
+/propertiesmanager.zip

--- a/build-all.sh
+++ b/build-all.sh
@@ -2,6 +2,8 @@
 # Build all project modules in dependency order
 set -euo pipefail
 
+CONFIG_ENV="${1:-dev}"
+
 mvn -q -f propertiesmanager-toolbox-file-lib/pom.xml install
 mvn -q -f propertiesmanager-database-lib/pom.xml install
 mvn -q -f propertiesmanager-api-lib/pom.xml install
@@ -10,5 +12,28 @@ mvn -q -f propertiesmanager-lib/pom.xml install
 mvn -q -f connector-java/pom.xml install
 mvn -q -f propertiesmanager-api/pom.xml install
 
-# Uncomment to build the UI with npm
-# npm install --prefix propertiesmanager-ui
+npm install --prefix propertiesmanager-ui
+npm --prefix propertiesmanager-ui run build:${CONFIG_ENV}
+
+DIST_DIR="dist"
+rm -rf "${DIST_DIR}"
+mkdir -p "${DIST_DIR}/propertiesmanager-ui"
+mkdir -p "${DIST_DIR}/propertiesmanager-api"
+mkdir -p "${DIST_DIR}/connector"
+
+cp -r propertiesmanager-ui/build/* "${DIST_DIR}/propertiesmanager-ui/"
+
+API_JAR=$(ls propertiesmanager-api/target/*.jar | head -n1)
+cp "${API_JAR}" "${DIST_DIR}/propertiesmanager-api/"
+
+CONNECTOR_JAR=$(ls connector-java/target/*.jar | head -n1)
+cp "${CONNECTOR_JAR}" "${DIST_DIR}/connector/"
+
+ZIP_NAME="propertiesmanager.zip"
+(
+  cd "${DIST_DIR}"
+  zip -qr "../${ZIP_NAME}" .
+)
+
+mkdir -p propertiesmanager-ui/download
+cp "${ZIP_NAME}" propertiesmanager-ui/download/propertiesmanager_latest.zip

--- a/propertiesmanager-ui/.gitignore
+++ b/propertiesmanager-ui/.gitignore
@@ -65,3 +65,4 @@ local.properties
 /package-lock.json
 /public/config/config.json
 /public/config/keycloak.json
+/download/


### PR DESCRIPTION
## Summary
- add CONFIG_ENV parameter to build script and run UI build accordingly
- package UI, API and connector into a ZIP and copy to UI/download
- pass environment to build-all in GitHub workflows

## Testing
- `./build-all.sh dev` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68abd3b033b0832c8aa6208f3bb87dce