### PR TITLE
feat(ui): refactor global variables screen

### DIFF
--- a/propertiesmanager-ui/src/Components/kustom/i18n.js
+++ b/propertiesmanager-ui/src/Components/kustom/i18n.js
@@ -73,6 +73,7 @@ i18n
           'globalvariable.editvalue': 'Valeur de remplacement',
           'globalvariable.remove.btn': 'Supprimer',
           'globalvariable.remove.confirm': 'Confirmer la suppression ?',
+          'globalvariable.newkey': 'Nouvelle clé',
           
         }
       },
@@ -132,6 +133,7 @@ i18n
           'globalvariable.editvalue': 'Replace value',
           'globalvariable.remove.btn': 'Remove',
           'globalvariable.remove.confirm': 'Confirm removal?',
+          'globalvariable.newkey': 'New key',
           
         }
       },
@@ -191,6 +193,7 @@ i18n
           'globalvariable.editvalue': 'Wert ersetzen',
           'globalvariable.remove.btn': 'Entfernen',
           'globalvariable.remove.confirm': 'Entfernung bestätigen?',
+          'globalvariable.newkey': 'Neuer Schlüssel',
           
         }
       },
@@ -251,6 +254,7 @@ i18n
           'globalvariable.editvalue': 'Wäert ersetzen',
           'globalvariable.remove.btn': 'Ewechmaachen',
           'globalvariable.remove.confirm': 'Entfernung bestätegt?',
+          'globalvariable.newkey': 'Neie Schlëssel',
           
         }
       }

--- a/propertiesmanager-ui/src/Components/kustom/pages/globalvariables/GlobalVariables.css
+++ b/propertiesmanager-ui/src/Components/kustom/pages/globalvariables/GlobalVariables.css
@@ -1,44 +1,51 @@
 .global-variables {
-	display: flex;
+        padding: 15px;
 }
 
-.variables-list {
-	display: block;
-	direction: rtl;
-	flex: 4;
-	padding: 15px;
-	max-height: 1100px;
-	overflow-y: scroll;
+.global-variables .add-panel {
+        display: flex;
+        flex-direction: row;
+        margin-bottom: 10px;
 }
 
-.variables-list .global-variable-item  {
-	direction: ltr;
-	padding: 5px 15px;
-	border-radius: 5px;
-	border: none;
+.global-variables table {
+        width: 100%;
+        border-collapse: collapse;
 }
 
-.variables-list .global-variable-item.selected  {
-	direction: rtl;
-	color: red;
-	background-color: rgb(128, 64, 64);
+.global-variables .global-variable-line-title {
+        margin: 0px 5px -1px 5px;
+        background-color: #000000;
+        font-weight: bold;
 }
 
-.variables-list .global-variable-item:hover  {
-	direction: rtl;
-	background-color: var(--background-form-hover);
-	color: var(--font-form-hover);
+.global-variables .global-variable-line:hover {
+        background-color: gray;
 }
 
-.edit-panel {
-	flex: 6;
-	height: 100%;
-	padding: 15px;
+.global-variables th,
+.global-variables td {
+        padding: 2px 5px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
 }
-.edit-panel button {
-	background-color: var(--background-title-ko);
-	color: var(--font-ko);
-	width: fit-content;
-	margin: auto;
-	margin-right: 0px;
+
+.global-variables .cell-content {
+        display: flex;
+        flex-direction: row;
+}
+
+.global-variables .cell-content .env-value {
+        flex: auto;
+}
+
+.global-variables .cell-content input {
+        flex: auto;
+}
+
+.global-variables .cell-content .env-action {
+        flex: 0;
+        padding: 2px 5px;
+        text-align: center;
 }

--- a/propertiesmanager-ui/src/Components/kustom/pages/globalvariables/GlobalVariables.js
+++ b/propertiesmanager-ui/src/Components/kustom/pages/globalvariables/GlobalVariables.js
@@ -8,168 +8,155 @@ import AppContext from '../../../AppContext';
 
 import ApiDefinition from '../../../kustom/api/ApiDefinition';
 import { ButtonUtils, TextInputUtils } from '../../../kustom/commons/HtmlUtils';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCheck, faXmark, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { t } from 'i18next';
 
 export default function GlobalVariables() {
 
-const { keycloak } = useKeycloakInstance();
+        const { keycloak } = useKeycloakInstance();
         const { app } = useContext(AppContext);
 
-	const [envList, setEnvList] = useState();
+        const [envList, setEnvList] = useState();
 
-	const [globalVariables, setGlobalVariables] = useState();
-	const [selectedVariable, setSelectedVariable] = useState();
-	
-	const [newGlobalVariable, setNewGlobalVariable] = useState();
-	
-	
+        const [globalVariables, setGlobalVariables] = useState();
 
+        const [newGlobalVariable, setNewGlobalVariable] = useState('');
+
+        const [editMode, setEditMode] = useState({});
 
 
-	
+        /* HOOKS */
 
-	/* HOOKS */
-	
         useEffect(() => {
-                app!=undefined?
+                app != undefined ?
                         setEnvList(app.env)
-                        :null;
+                        : null;
         }, [app]);
-	
-useEffect(() => {
-if (keycloak?.authenticated && envList != undefined) {
-refreshGlobalVariables();
-}
-}, [envList, keycloak?.authenticated]);
-	
-	
 
-	
-	
-	
+        useEffect(() => {
+                if (keycloak?.authenticated && envList != undefined) {
+                        refreshGlobalVariables();
+                }
+        }, [envList, keycloak?.authenticated]);
 
 
-	
-	
-	
-	/* HANDLERS */
-		
-	function selectVariableCallback(key) {
-		console.log("selectVariable : ", key);
-		setSelectedVariable(key);
-	}
-		
-	function addNewGlobalVariableCallback(newKey) {
-		console.log("addNewGlobalVariableCallback : ", newKey);
-		addNewGlobalVariables(newKey);
-	}
-		
-	let saveTimeout = undefined;
-	function updateGlobalVariableCallback(key, envId, newValue) {
-		console.log("updateGlobalVariableCallback : ", key, envId, newValue);
-		if (saveTimeout !== undefined) {
-			clearTimeout(saveTimeout);
-		}
-		saveTimeout = setTimeout(() => {
-				updateGlobalVariableValue(key, envId, newValue);
-			}, 1500);
-	}
-		
-	function deleteGlobalVariableCallback(key) {
-		console.log("deleteGlobalVariableCallback : ", key);
-		if (confirm(t('globalvariable.remove.confirm'))) {
-			deleteGlobalVariable(key);
-		}
-	}
-	
-	
-	
+        /* HANDLERS */
+
+        function addNewGlobalVariableCallback() {
+                addNewGlobalVariables(newGlobalVariable);
+        }
+
+        function deleteGlobalVariableCallback(key) {
+                if (confirm(t('globalvariable.remove.confirm'))) {
+                        deleteGlobalVariable(key);
+                }
+        }
+
+        function switchEditMode(env, key, mode) {
+                const cellId = env + '_' + key;
+                setEditMode((prev) => {
+                        const copy = { ...prev };
+                        if (mode) {
+                                copy[cellId] = true;
+                        } else {
+                                delete copy[cellId];
+                        }
+                        return copy;
+                });
+        }
+
+        function updateGlobalVariableCallback(key, env, value) {
+                updateGlobalVariableValue(key, env, value);
+        }
 
 
+        /* UTILS */
+        function refreshGlobalVariables() {
+                ApiDefinition.getGlobalVariables((data) => {
+                        setGlobalVariables(data);
+                });
+        }
+        function addNewGlobalVariables(newKey) {
+                ApiDefinition.addGlobalVariable(newKey, () => {
+                        refreshGlobalVariables();
+                        setNewGlobalVariable('');
+                });
+        }
+        function updateGlobalVariableValue(key, env, value) {
+                ApiDefinition.updateGlobalVariableValue(key, env, value, () => {
+                        refreshGlobalVariables();
+                        switchEditMode(env, key, false);
+                });
+        }
+        function deleteGlobalVariable(key) {
+                ApiDefinition.deleteGlobalVariable(key, () => {
+                        refreshGlobalVariables();
+                });
+        }
 
 
-
-
-
-	/* UTILS */
-	function refreshGlobalVariables() {
-		ApiDefinition.getGlobalVariables((data) => {
-			console.log(data);
-			setGlobalVariables(data);
-		});
-	}
-	function addNewGlobalVariables(newKey) {
-		ApiDefinition.addGlobalVariable(newKey, () => {
-			refreshGlobalVariables();
-			setNewGlobalVariable('');
-		});
-	}
-	function updateGlobalVariableValue(key, env, value) {
-		ApiDefinition.updateGlobalVariableValue(key, env, value, () => {
-			refreshGlobalVariables();
-		});
-	}
-	function deleteGlobalVariable(key) {
-		ApiDefinition.deleteGlobalVariable(key, () => {
-			refreshGlobalVariables();
-			setSelectedVariable(undefined);
-		});
-	}
-
-	
-	
-	
-	
-
-
-	return (
-		<div className="global-variables">
-			<div className="variables-list">
-				{
-					Keycloak.securityAdminCheck()?<React.Fragment>
-						<div className="add-panel">
-							<TextInputUtils id="newGlobalVariableKey" label={t('globalvariable.addnew')} value={newGlobalVariable} onChange={setNewGlobalVariable} />
-							<ButtonUtils inactive={newGlobalVariable===undefined} label={t('globalvariable.addnew.btn')} onClick={() => {addNewGlobalVariableCallback(newGlobalVariable)}} />
-						</div>
-					</React.Fragment>:null
-				}
-				<ListGlobalVariables list={globalVariables?.keys} selectedVariable={selectedVariable} onClick={selectVariableCallback} />
-			</div>
-			<div className="edit-panel">
-				{
-					selectedVariable!==undefined?<React.Fragment>
-						<h2>{selectedVariable}</h2>
-						<GlobalVariablePanel envList={envList} variable={selectedVariable} values={globalVariables.values?.[selectedVariable]} onChange={updateGlobalVariableCallback} />
-						<div className="spacer" />
-						<ButtonUtils label={t('globalvariable.remove.btn')} onClick={() => {deleteGlobalVariableCallback(selectedVariable)}} />
-					</React.Fragment>:null
-				}
-			</div>
-		</div>
-	);
-}
-
-
-
-
-
-function ListGlobalVariables(props) {
-	return <React.Fragment>
-			{
-				props.list?.map((gv) => {return <div key={gv.globalVariableKey} className={(props.selectedVariable==gv.globalVariableKey)?"global-variable-item selected":"global-variable-item"} onClick={(_e) => {props.onClick(gv.globalVariableKey)}}>{gv.globalVariableKey}</div>})
-			}
-		</React.Fragment>;
-}
-
-function GlobalVariablePanel(props) {
-	return <React.Fragment>
-			{
-				props.envList?.map((env) => {
-					return <TextInputUtils key={props.variable + "_" + env} label={t('globalvariable.editvalue') + ' : ' + env} defaultValue={props.values?.[env]?.newValue}
-								onChange={(e) => {props.onChange(props.variable, env, e)}} />;
-				})
-			}
-		</React.Fragment>;
+        /* RENDER */
+        return (
+                <div className="global-variables">
+                        {
+                                Keycloak.securityAdminCheck() ? <div className="add-panel">
+                                        <TextInputUtils id="newGlobalVariableKey" label={t('globalvariable.newkey')} value={newGlobalVariable} onChange={setNewGlobalVariable} />
+                                        <ButtonUtils inactive={newGlobalVariable === undefined || newGlobalVariable === ''} label={t('globalvariable.addnew.btn')} onClick={() => { addNewGlobalVariableCallback(); }} />
+                                </div> : null
+                        }
+                        <table>
+                                <thead>
+                                        <tr className="global-variable-line-title">
+                                                <th>{t('appdetails.table.title.key')}</th>
+                                                {envList?.map((env) => { return <th key={env}>{env}</th>; })}
+                                                <th></th>
+                                        </tr>
+                                </thead>
+                                <tbody>
+                                        {
+                                                globalVariables?.keys?.map((gv) => {
+                                                        return <tr key={gv.globalVariableKey} className="global-variable-line">
+                                                                <td className="global-variable-key"><div className="cell-content"><span>{gv.globalVariableKey}</span></div></td>
+                                                                {
+                                                                        envList?.map((env) => {
+                                                                                const cellId = env + '_' + gv.globalVariableKey;
+                                                                                const inputId = 'input_' + cellId;
+                                                                                const localValue = globalVariables.values?.[gv.globalVariableKey]?.[env]?.newValue;
+                                                                                return editMode[cellId] ?
+                                                                                        <td key={cellId}>
+                                                                                                <div className="cell-content">
+                                                                                                        <input autoFocus id={inputId} className="env-value" type="text" defaultValue={localValue}
+                                                                                                                onKeyDown={(e) => {
+                                                                                                                        if (e.key === 'Enter') updateGlobalVariableCallback(gv.globalVariableKey, env, document.getElementById(inputId).value);
+                                                                                                                        if (e.key === 'Escape') switchEditMode(env, gv.globalVariableKey, false);
+                                                                                                                }} />
+                                                                                                        <FontAwesomeIcon className="env-action" icon={faCheck} onClick={() => { updateGlobalVariableCallback(gv.globalVariableKey, env, document.getElementById(inputId).value); }} />
+                                                                                                        <FontAwesomeIcon className="env-action" icon={faXmark} onClick={() => { switchEditMode(env, gv.globalVariableKey, false); }} />
+                                                                                                </div>
+                                                                                        </td>
+                                                                                        :
+                                                                                        <td key={cellId}>
+                                                                                                <div className="cell-content">
+                                                                                                        <span className="env-value" onDoubleClick={() => { switchEditMode(env, gv.globalVariableKey, true); }}>
+                                                                                                                {localValue !== undefined && localValue !== null ? localValue : <i>{t('appdetails.novalue')}</i>}
+                                                                                                        </span>
+                                                                                                </div>
+                                                                                        </td>;
+                                                                        })
+                                                                }
+                                                                <td>
+                                                                        {Keycloak.securityAdminCheck() ? <div className="cell-content">
+                                                                                <span className="env-action" onClick={() => { deleteGlobalVariableCallback(gv.globalVariableKey); }}><FontAwesomeIcon className="error" icon={faTrash} /></span>
+                                                                        </div> : null}
+                                                                </td>
+                                                        </tr>;
+                                                })
+                                        }
+                                </tbody>
+                        </table>
+                </div>
+        );
 }
 
 


### PR DESCRIPTION
## Summary
- replace global variables view with editable table and add form
- add translations and styling for new global variable input

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bbcc291eec832cb5b61eb6cc4530df