### PR TITLE
Hide property values from connector logs

### DIFF
--- a/connector-java/src/main/java/com/opyruso/propertiesmanager/connector/services/UpdatePropertiesCommandService.java
+++ b/connector-java/src/main/java/com/opyruso/propertiesmanager/connector/services/UpdatePropertiesCommandService.java
@@ -64,13 +64,13 @@ public class UpdatePropertiesCommandService {
 			apiClient.addInstalledVersion(projectId, version, env);
 			apiClient.addOrUpdateFile(projectId, version, addOrUpdateFileRequest);
 			ApiGenerateConfigResponse response = apiClient.getGeneratedConfig(request);
-			if (response.logs != null) {
-				for (ApiLog log : response.logs) {
-					System.out.println(log.status + " : " + log.comment);
-				}
-			} else {
-				System.out.println("WARNING : Pas de log retour...");
-			}
+                        if (response.logs != null) {
+                                for (ApiLog log : response.logs) {
+                                        System.out.println(log.status);
+                                }
+                        } else {
+                                System.out.println("WARNING : Pas de log retour...");
+                        }
 			System.out.println("Updated : " + Files.write(file.toPath(), Base64.getDecoder().decode(response.fileContentAsBase64), StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE).toAbsolutePath());
 			
 		} else {


### PR DESCRIPTION
## Summary
- Avoid logging property values in UpdatePropertiesCommandService

## Testing
- `./build-all.sh` *(fails: Non-resolvable import POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc58c2dbf8832ca91f0d4aaff6b055