### PR TITLE
Expand search criteria and adjust search UI

### DIFF
--- a/propertiesmanager-api-lib/src/main/java/com/opyruso/propertiesmanager/api/IApplicationResources.java
+++ b/propertiesmanager-api-lib/src/main/java/com/opyruso/propertiesmanager/api/IApplicationResources.java
@@ -99,7 +99,7 @@ public interface IApplicationResources {
           public Response createSnapshot(@PathParam("appId") String appId) throws WebApplicationException;
         @GET
         @Path("/search")
-        public Response search(@QueryParam("value") String value) throws WebApplicationException;
+        public Response search(@QueryParam("value") String value, @QueryParam("archives") @DefaultValue("false") boolean archives) throws WebApplicationException;
 
 	@GET
 	@Path("/globalvariables")

--- a/propertiesmanager-api/src/main/java/com/opyruso/propertiesmanager/api/ApplicationResources.java
+++ b/propertiesmanager-api/src/main/java/com/opyruso/propertiesmanager/api/ApplicationResources.java
@@ -374,9 +374,9 @@ public class ApplicationResources implements IApplicationResources {
 
         
         @Override
-        public Response search(String value) throws WebApplicationException {
+        public Response search(String value, boolean archives) throws WebApplicationException {
                 try {
-                        return Response.ok(applicationService.search(value)).build();
+                        return Response.ok(applicationService.search(value, archives)).build();
                 } catch (Exception e) {
                         Log.error("Error:", e);
                         throw new WebApplicationException(HttpStatus.SC_INTERNAL_SERVER_ERROR);

--- a/propertiesmanager-api/src/main/java/com/opyruso/propertiesmanager/data/impl/ApplicationDataService.java
+++ b/propertiesmanager-api/src/main/java/com/opyruso/propertiesmanager/data/impl/ApplicationDataService.java
@@ -5,6 +5,7 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -498,12 +499,29 @@ public class ApplicationDataService implements IApplicationDataService {
         public List<Object[]> searchPropertyValues(String value) {
                 boolean isAdmin = KeycloakAttributesUtils.securityCheckIsAdminAsBoolean(jwt);
                 boolean isConnector = KeycloakAttributesUtils.securityCheckIsConnectorAsBoolean(jwt);
-                String sql = "SELECT pv.app_id, a.app_label, a.app_product_owner, pv.num_version, pv.env_id, iv.update_date, pv.property_key, pv.new_value FROM property_value pv JOIN applications a ON pv.app_id = a.app_id LEFT JOIN installed_version iv ON pv.app_id = iv.app_id AND pv.num_version = iv.num_version AND pv.env_id = iv.env_id WHERE LOWER(pv.new_value) LIKE ?1";
+                String baseSql = "SELECT pv.app_id, a.app_label, a.app_product_owner, pv.num_version, pv.env_id, iv.update_date, pv.property_key, pv.new_value FROM property_value pv JOIN applications a ON pv.app_id = a.app_id LEFT JOIN installed_version iv ON pv.app_id = iv.app_id AND pv.num_version = iv.num_version AND pv.env_id = iv.env_id WHERE ";
+
+                String[] tokens = value == null ? new String[0] : value.toLowerCase().split("\\s+");
+                if (tokens.length == 0) {
+                        return Collections.emptyList();
+                }
+                List<String> criteria = new ArrayList<>();
+                for (int i = 0; i < tokens.length; i++) {
+                        criteria.add("(LOWER(pv.new_value) LIKE ?" + (i + 1)
+                                        + " OR LOWER(pv.property_key) LIKE ?" + (i + 1)
+                                        + " OR LOWER(a.app_product_owner) LIKE ?" + (i + 1)
+                                        + " OR LOWER(a.app_label) LIKE ?" + (i + 1) + ")");
+                }
+                String sql = baseSql + String.join(" AND ", criteria);
                 if (!isAdmin && !isConnector) {
                         sql += " AND pv.is_protected = false";
                 }
+
                 Query q = propertyValueRepository.getEntityManager().createNativeQuery(sql);
-                q.setParameter(1, "%" + value.toLowerCase() + "%");
+                for (int i = 0; i < tokens.length; i++) {
+                        q.setParameter(i + 1, "%" + tokens[i] + "%");
+                }
+
                 List<Object[]> tmp = q.getResultList();
                 List<Object[]> result = new ArrayList<>();
                 for (Object[] o : tmp) {

--- a/propertiesmanager-api/src/main/java/com/opyruso/propertiesmanager/data/impl/ApplicationDataService.java
+++ b/propertiesmanager-api/src/main/java/com/opyruso/propertiesmanager/data/impl/ApplicationDataService.java
@@ -510,7 +510,8 @@ public class ApplicationDataService implements IApplicationDataService {
                         criteria.add("(LOWER(pv.new_value) LIKE ?" + (i + 1)
                                         + " OR LOWER(pv.property_key) LIKE ?" + (i + 1)
                                         + " OR LOWER(a.app_product_owner) LIKE ?" + (i + 1)
-                                        + " OR LOWER(a.app_label) LIKE ?" + (i + 1) + ")");
+                                        + " OR LOWER(a.app_label) LIKE ?" + (i + 1)
+                                        + " OR LOWER(pv.num_version) LIKE ?" + (i + 1) + ")");
                 }
                 String sql = baseSql + String.join(" AND ", criteria);
                 if (!isAdmin && !isConnector) {

--- a/propertiesmanager-api/src/main/java/com/opyruso/propertiesmanager/services/impl/ApplicationService.java
+++ b/propertiesmanager-api/src/main/java/com/opyruso/propertiesmanager/services/impl/ApplicationService.java
@@ -137,9 +137,9 @@ public class ApplicationService implements IApplicationService {
 	}
 
         @Override
-        public List<ApiSearchResult> search(String value) throws WebApplicationException {
+        public List<ApiSearchResult> search(String value, boolean includeArchived) throws WebApplicationException {
                 try {
-                        List<Object[]> data = dataService.searchPropertyValues(value);
+                        List<Object[]> data = dataService.searchPropertyValues(value, includeArchived);
                         List<ApiSearchResult> result = new ArrayList<>();
                         for (Object[] o : data) {
                                 ApiSearchResult r = new ApiSearchResult();

--- a/propertiesmanager-database-lib/src/main/java/com/opyruso/propertiesmanager/data/IApplicationDataService.java
+++ b/propertiesmanager-database-lib/src/main/java/com/opyruso/propertiesmanager/data/IApplicationDataService.java
@@ -114,6 +114,6 @@ public interface IApplicationDataService {
 
         void cleanPropertiesByVersion(String appId, String version) throws SQLException;
 
-        List<Object[]> searchPropertyValues(String value) throws SQLException;
+        List<Object[]> searchPropertyValues(String value, boolean includeArchived) throws SQLException;
 
 }

--- a/propertiesmanager-lib/src/main/java/com/opyruso/propertiesmanager/services/IApplicationService.java
+++ b/propertiesmanager-lib/src/main/java/com/opyruso/propertiesmanager/services/IApplicationService.java
@@ -29,7 +29,7 @@ public interface IApplicationService {
 
 	public Map<String, ApiInstalledVersion> getApplicationInstalledVersions(String appId) throws WebApplicationException;
 
-        public List<ApiSearchResult> search(String value) throws WebApplicationException;
+        public List<ApiSearchResult> search(String value, boolean includeArchived) throws WebApplicationException;
 
         public Map<String, Long> getApplicationLastReleaseDate(String appId) throws WebApplicationException;
 

--- a/propertiesmanager-ui/src/Components/kernel/Standard.css
+++ b/propertiesmanager-ui/src/Components/kernel/Standard.css
@@ -97,6 +97,7 @@ button:hover:enabled {
 
 span.underline {
         background-color: lightgoldenrodyellow;
+        color: black;
 }
 
 

--- a/propertiesmanager-ui/src/Components/kustom/api/ApiDefinition.js
+++ b/propertiesmanager-ui/src/Components/kustom/api/ApiDefinition.js
@@ -681,7 +681,8 @@ export default {
 	
         searchValues(value, callback = (data) => {console.log("searchValues default success log"), data}, callbackError = (e) => {console.error("searchValues default err log", e)}) {
                 try {
-                        ApiCallUtils.getSecure('/search?value=' + encodeURIComponent(value),
+                        const archives = localStorage.getItem('withArchives') === 'true';
+                        ApiCallUtils.getSecure('/search?value=' + encodeURIComponent(value) + (archives ? '&archives=true' : ''),
                                 (data) => {
                                         console.log("success searchValues callback", data);
                                         callback(data);

--- a/propertiesmanager-ui/src/Components/kustom/commons/Functions.js
+++ b/propertiesmanager-ui/src/Components/kustom/commons/Functions.js
@@ -37,6 +37,8 @@ export const underlineSearchAndReplace = (subject, find) => {
         return result;
 }
 
+const escapeRegExp = (s) => s.replace(/[-/\\^$*+?.()|[\]{}]/g, '\$&');
+
 const underlineToken = (subject, token) => {
         if (Array.isArray(subject)) {
                 let res = [];
@@ -46,14 +48,18 @@ const underlineToken = (subject, token) => {
                 return res;
         } else if (typeof subject !== 'string')
                 return subject;
-        const parts = subject.split(token);
+        const escaped = escapeRegExp(token);
+        const regex = new RegExp(`(${escaped})`, 'gi');
+        const parts = subject.split(regex);
+        if (parts.length === 1) return subject;
         const res = [];
         for (let i = 0; i < parts.length; i++) {
-                res.push(parts[i]);
-                if ((i + 1) !== parts.length)
-                        res.push(<span className="underline">{token}</span>);
+                if (i % 2 === 1) {
+                        res.push(<span className="underline">{parts[i]}</span>);
+                } else {
+                        res.push(parts[i]);
+                }
         }
-        if (res.length === 0) res.push(subject);
         return res;
 }
 

--- a/propertiesmanager-ui/src/Components/kustom/commons/Functions.js
+++ b/propertiesmanager-ui/src/Components/kustom/commons/Functions.js
@@ -27,23 +27,34 @@ export const replaceJSXRecursive = (subject, replacements) => {
 
 
 export const underlineSearchAndReplace = (subject, find) => {
-	if (find.trim().length === 0) return subject;
-	
-	const result = [];
-	if (Array.isArray(subject)) {
-		for (let part of subject)
-			result = [...result, searchAndReplace(part, find)]
-		return result;
-	} else if (typeof subject !== 'string')
-		return subject;
-	let parts = subject.split(find);
-	for (let i = 0; i < parts.length; i++) {
-		result.push(parts[i]);
-		if ((i + 1) !== parts.length)
-			result.push(<span className="underline">{find}</span>);
-	}
-	if (result.length === 0) result.push(subject);
-	return result;
+        const tokens = find.trim().split(/\s+/).filter(t => t.length > 0);
+        if (tokens.length === 0) return subject;
+
+        let result = subject;
+        for (let token of tokens) {
+                result = underlineToken(result, token);
+        }
+        return result;
+}
+
+const underlineToken = (subject, token) => {
+        if (Array.isArray(subject)) {
+                let res = [];
+                for (let part of subject) {
+                        res = res.concat(underlineToken(part, token));
+                }
+                return res;
+        } else if (typeof subject !== 'string')
+                return subject;
+        const parts = subject.split(token);
+        const res = [];
+        for (let i = 0; i < parts.length; i++) {
+                res.push(parts[i]);
+                if ((i + 1) !== parts.length)
+                        res.push(<span className="underline">{token}</span>);
+        }
+        if (res.length === 0) res.push(subject);
+        return res;
 }
 
 export const underlineProperties = (subject, find) => {

--- a/propertiesmanager-ui/src/Components/kustom/pages/search/Search.css
+++ b/propertiesmanager-ui/src/Components/kustom/pages/search/Search.css
@@ -9,11 +9,13 @@
         display: flex;
         flex-direction: row;
         align-items: center;
+        width: 100%;
 }
 
 .search .search-input {
         margin: 5px 5px 5px 5px;
         font-size: 1em;
+        flex: 1;
 }
 
 .search table {

--- a/propertiesmanager-ui/src/Components/kustom/pages/search/Search.js
+++ b/propertiesmanager-ui/src/Components/kustom/pages/search/Search.js
@@ -22,7 +22,7 @@ export default function Search() {
         }
 
         function goTo(result) {
-                localStorage.setItem('appDetails_env', result.envId);
+                localStorage.setItem('appDetails_env', JSON.stringify({ [result.envId]: true }));
                 localStorage.setItem('appDetails_filter_' + result.appId, value);
                 navigate('/app/' + result.appId + '/version/' + result.numVersion);
         }
@@ -51,15 +51,15 @@ export default function Search() {
                                                 results === undefined || results.length === 0 ?
                                                         <tr className="search-line"><td className="no-data" colSpan="7">{t('search.noresult')}</td></tr>
                                                         : results.map((r, i) =>
-                                                                <tr key={i} className="search-line" onClick={() => goTo(r)}>
-                                                                        <td className="app-label">{r.appLabel}</td>
-                                                                        <td className="product-owner">{r.productOwner}</td>
-                                                                        <td className="version">{r.numVersion}</td>
-                                                                        <td className="env">{r.envId}</td>
-                                                                        <td className="deploy-date">{r.deployDate ? new Date(r.deployDate).toLocaleString() : '-'}</td>
-                                                                        <td className="key">{r.propertyKey}</td>
-                                                                        <td className="value">{underlineSearchAndReplace(r.value || '', value)}</td>
-                                                                </tr>
+                                                                        <tr key={i} className="search-line" onClick={() => goTo(r)}>
+                                                                                <td className="app-label">{underlineSearchAndReplace(r.appLabel || '', value)}</td>
+                                                                                <td className="product-owner">{underlineSearchAndReplace(r.productOwner || '', value)}</td>
+                                                                                <td className="version">{underlineSearchAndReplace(r.numVersion || '', value)}</td>
+                                                                                <td className="env">{r.envId}</td>
+                                                                                <td className="deploy-date">{r.deployDate ? new Date(r.deployDate).toLocaleString() : '-'}</td>
+                                                                                <td className="key">{underlineSearchAndReplace(r.propertyKey || '', value)}</td>
+                                                                                <td className="value">{underlineSearchAndReplace(r.value || '', value)}</td>
+                                                                        </tr>
                                                         )
                                         }
                                 </tbody>

--- a/propertiesmanager-ui/src/Components/kustom/pages/search/Search.js
+++ b/propertiesmanager-ui/src/Components/kustom/pages/search/Search.js
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import './Search.css';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
 import ApiDefinition from '../../api/ApiDefinition';
 import { underlineSearchAndReplace } from '../../commons/Functions';
+import { subscribe, unsubscribe } from '../../../AppStaticData';
 
 export default function Search() {
         const { t } = useTranslation();
@@ -23,9 +24,19 @@ export default function Search() {
 
         function goTo(result) {
                 localStorage.setItem('appDetails_env', JSON.stringify({ [result.envId]: true }));
-                localStorage.setItem('appDetails_filter_' + result.appId, value);
+                localStorage.removeItem('appDetails_filter_' + result.appId);
                 navigate('/app/' + result.appId + '/version/' + result.numVersion);
         }
+
+        useEffect(() => {
+                const listener = () => {
+                        if (value.trim() !== '') {
+                                doSearch();
+                        }
+                };
+                subscribe('archivesChangeEvent', listener);
+                return () => unsubscribe('archivesChangeEvent', listener);
+        }, [value]);
 
         return (
                 <div className="search">


### PR DESCRIPTION
## Summary
- Expand backend search to match value, key, owner and app name with multi-word terms.
- Highlight multiple search terms in UI and style results with black underlines.
- Make search bar full width for easier use.

## Testing
- ⚠️ `./build-all.sh` *(failed: Non-resolvable import POM: Network is unreachable)*
- ⚠️ `npm test -- --watchAll=false` *(No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbb109fb0832c88455b3c79c087e1