### PR TITLE
feat: add security mode toggle on search results

### DIFF
--- a/propertiesmanager-api-lib/src/main/java/com/opyruso/propertiesmanager/api/entity/ApiSearchResult.java
+++ b/propertiesmanager-api-lib/src/main/java/com/opyruso/propertiesmanager/api/entity/ApiSearchResult.java
@@ -14,5 +14,6 @@ public class ApiSearchResult {
     public Timestamp deployDate;
     public String propertyKey;
     public String value;
+    public boolean isProtected;
 }
 

--- a/propertiesmanager-api/src/main/java/com/opyruso/propertiesmanager/data/impl/ApplicationDataService.java
+++ b/propertiesmanager-api/src/main/java/com/opyruso/propertiesmanager/data/impl/ApplicationDataService.java
@@ -499,7 +499,7 @@ public class ApplicationDataService implements IApplicationDataService {
         public List<Object[]> searchPropertyValues(String value, boolean includeArchived) {
                 boolean isAdmin = KeycloakAttributesUtils.securityCheckIsAdminAsBoolean(jwt);
                 boolean isConnector = KeycloakAttributesUtils.securityCheckIsConnectorAsBoolean(jwt);
-                String baseSql = "SELECT pv.app_id, a.app_label, a.app_product_owner, pv.num_version, pv.env_id, iv.update_date, pv.property_key, pv.new_value FROM property_value pv JOIN applications a ON pv.app_id = a.app_id JOIN application_version v ON pv.app_id = v.app_id AND pv.num_version = v.num_version LEFT JOIN installed_version iv ON pv.app_id = iv.app_id AND pv.num_version = iv.num_version AND pv.env_id = iv.env_id WHERE ";
+                String baseSql = "SELECT pv.app_id, a.app_label, a.app_product_owner, pv.num_version, pv.env_id, iv.update_date, pv.property_key, pv.new_value, pv.is_protected FROM property_value pv JOIN applications a ON pv.app_id = a.app_id JOIN application_version v ON pv.app_id = v.app_id AND pv.num_version = v.num_version LEFT JOIN installed_version iv ON pv.app_id = iv.app_id AND pv.num_version = iv.num_version AND pv.env_id = iv.env_id WHERE ";
 
                 String[] tokens = value == null ? new String[0] : value.toLowerCase().split("\\s+");
                 if (tokens.length == 0) {

--- a/propertiesmanager-api/src/main/java/com/opyruso/propertiesmanager/services/impl/ApplicationService.java
+++ b/propertiesmanager-api/src/main/java/com/opyruso/propertiesmanager/services/impl/ApplicationService.java
@@ -151,6 +151,7 @@ public class ApplicationService implements IApplicationService {
                                 r.deployDate = (java.sql.Timestamp) o[5];
                                 r.propertyKey = (String) o[6];
                                 r.value = (String) o[7];
+                                r.isProtected = o[8] != null && (Boolean) o[8];
                                 result.add(r);
                         }
                         return result;

--- a/propertiesmanager-ui/src/Components/kustom/pages/search/Search.css
+++ b/propertiesmanager-ui/src/Components/kustom/pages/search/Search.css
@@ -54,3 +54,9 @@
         border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
+.search .value .lock {
+        margin-left: 5px;
+        color: rgb(255, 0, 0);
+        cursor: pointer;
+}
+

--- a/propertiesmanager-ui/src/Components/kustom/pages/search/Search.js
+++ b/propertiesmanager-ui/src/Components/kustom/pages/search/Search.js
@@ -64,30 +64,33 @@ export default function Search() {
                                         {
                                                 results === undefined || results.length === 0 ?
                                                         <tr className="search-line"><td className="no-data" colSpan="7">{t('search.noresult')}</td></tr>
-                                                        : results.map((r, i) =>
-                                                                        <tr key={i} className="search-line" onClick={() => goTo(r)}>
-                                                                                <td className="app-label">{underlineSearchAndReplace(r.appLabel || '', value)}</td>
-                                                                                <td className="product-owner">{underlineSearchAndReplace(r.productOwner || '', value)}</td>
-                                                                                <td className="version">{underlineSearchAndReplace(r.numVersion || '', value)}</td>
-                                                                                <td className="env">{r.envId}</td>
-                                                                                <td className="deploy-date">{r.deployDate ? new Date(r.deployDate).toLocaleString() : '-'}</td>
-                                                                                <td className="key">{underlineSearchAndReplace(r.propertyKey || '', value)}</td>
-                                                                                <td className="value">
-                                                                                        {
-                                                                                                parseInt(localStorage.streamer_mod) === 1 ?
-                                                                                                        <span>
-                                                                                                                {revealed[i] ? underlineSearchAndReplace(r.value || '', value) : '*****'}
-                                                                                                                <FontAwesomeIcon className="lock" icon={faLock} onClick={(e)=>{e.stopPropagation(); setRevealed(prev=>({...prev, [i]: !prev[i]}));}} />
-                                                                                                        </span>
-                                                                                                        : underlineSearchAndReplace(r.value || '', value)
-                                                                                        }
-                                                                                </td>
-                                                                        </tr>
-                                                        )
-                                        }
-                                </tbody>
-                        </table>
-                </div>
+                                                        : results.map((r, i) => {
+                                                                        const isProtected = r.isProtected || r.is_protected;
+                                                                        return (
+                                                                                <tr key={i} className="search-line" onClick={() => goTo(r)}>
+                                                                                        <td className="app-label">{underlineSearchAndReplace(r.appLabel || '', value)}</td>
+                                                                                        <td className="product-owner">{underlineSearchAndReplace(r.productOwner || '', value)}</td>
+                                                                                        <td className="version">{underlineSearchAndReplace(r.numVersion || '', value)}</td>
+                                                                                        <td className="env">{r.envId}</td>
+                                                                                        <td className="deploy-date">{r.deployDate ? new Date(r.deployDate).toLocaleString() : '-'}</td>
+                                                                                        <td className="key">{underlineSearchAndReplace(r.propertyKey || '', value)}</td>
+                                                                                        <td className="value">
+                                                                                                {
+                                                                                                        parseInt(localStorage.streamer_mod) === 1 && isProtected ?
+                                                                                                                <span>
+                                                                                                                        {revealed[i] ? underlineSearchAndReplace(r.value || '', value) : '*****'}
+                                                                                                                        <FontAwesomeIcon className="lock" icon={faLock} onClick={(e)=>{e.stopPropagation(); setRevealed(prev=>({...prev, [i]: !prev[i]}));}} />
+                                                                                                                </span>
+                                                                                                                : underlineSearchAndReplace(r.value || '', value)
+                                                                                                }
+                                                                                        </td>
+                                                                                </tr>
+                                                                        );
+                                                        })
+                                       }
+                               </tbody>
+                       </table>
+               </div>
         );
 }
 

--- a/propertiesmanager-ui/src/Components/kustom/pages/search/Search.js
+++ b/propertiesmanager-ui/src/Components/kustom/pages/search/Search.js
@@ -6,16 +6,19 @@ import { useNavigate } from 'react-router-dom';
 import ApiDefinition from '../../api/ApiDefinition';
 import { underlineSearchAndReplace } from '../../commons/Functions';
 import { subscribe, unsubscribe } from '../../../AppStaticData';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faLock } from '@fortawesome/free-solid-svg-icons';
 
 export default function Search() {
         const { t } = useTranslation();
         const navigate = useNavigate();
         const [value, setValue] = useState('');
         const [results, setResults] = useState();
+        const [revealed, setRevealed] = useState({});
 
         function doSearch() {
                 if (value.trim() === '') return;
-                ApiDefinition.searchValues(value.trim(), (data) => { setResults(data); });
+                ApiDefinition.searchValues(value.trim(), (data) => { setResults(data); setRevealed({}); });
         }
 
         function handleKey(e) {
@@ -69,7 +72,16 @@ export default function Search() {
                                                                                 <td className="env">{r.envId}</td>
                                                                                 <td className="deploy-date">{r.deployDate ? new Date(r.deployDate).toLocaleString() : '-'}</td>
                                                                                 <td className="key">{underlineSearchAndReplace(r.propertyKey || '', value)}</td>
-                                                                                <td className="value">{underlineSearchAndReplace(r.value || '', value)}</td>
+                                                                                <td className="value">
+                                                                                        {
+                                                                                                parseInt(localStorage.streamer_mod) === 1 ?
+                                                                                                        <span>
+                                                                                                                {revealed[i] ? underlineSearchAndReplace(r.value || '', value) : '*****'}
+                                                                                                                <FontAwesomeIcon className="lock" icon={faLock} onClick={(e)=>{e.stopPropagation(); setRevealed(prev=>({...prev, [i]: !prev[i]}));}} />
+                                                                                                        </span>
+                                                                                                        : underlineSearchAndReplace(r.value || '', value)
+                                                                                        }
+                                                                                </td>
                                                                         </tr>
                                                         )
                                         }

--- a/propertiesmanager-ui/src/Components/kustom/pages/search/Search.js
+++ b/propertiesmanager-ui/src/Components/kustom/pages/search/Search.js
@@ -65,7 +65,7 @@ export default function Search() {
                                                 results === undefined || results.length === 0 ?
                                                         <tr className="search-line"><td className="no-data" colSpan="7">{t('search.noresult')}</td></tr>
                                                         : results.map((r, i) => {
-                                                                        const isProtected = r.isProtected || r.is_protected;
+                                                                        const isProtected = r.isProtected;
                                                                         return (
                                                                                 <tr key={i} className="search-line" onClick={() => goTo(r)}>
                                                                                         <td className="app-label">{underlineSearchAndReplace(r.appLabel || '', value)}</td>


### PR DESCRIPTION
## Summary
- handle security mode in search page, hiding values behind stars with toggleable red padlock

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68bdc879d080832caf12197c7ccc40e4