### PR TITLE
Fix 404 error on login route

### DIFF
--- a/propertiesmanager-ui/src/Components/kustom/AppRouter.js
+++ b/propertiesmanager-ui/src/Components/kustom/AppRouter.js
@@ -21,9 +21,10 @@ const { keycloak, initialized } = useKeycloakInstance();
 
 	return (
 			<Routes>
-				<Route exact path="/" element={globalCondition(security(<Navigate to="/apps" />))} />
-				
-				<Route exact path="/apps" element={globalCondition(security(<AppList />))} />
+                                <Route exact path="/" element={globalCondition(security(<Navigate to="/apps" />))} />
+                                <Route exact path="/login" element={globalCondition(security(<Navigate to="/apps" />))} />
+
+                                <Route exact path="/apps" element={globalCondition(security(<AppList />))} />
 				<Route exact path="/app/:appId/version/:version" element={globalCondition(security(<AppDetails />))} />
                                   <Route exact path="/config-helper" element={globalCondition(security(<ConfigHelper />))} />
                                   <Route exact path="/search" element={globalCondition(security(<Search />))} />


### PR DESCRIPTION
## Summary
- add explicit `/login` route to redirect authenticated users to `/apps`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68bdcfb65b14832cbe6027733ed18f8a